### PR TITLE
Installation instructions and k8s config example 

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,130 @@
+# Installation Instructions 
+
+## Pre-Requisites
+- Monitoring-User (nagios) with Home-Dir (/home/nagios) is setup 
+- NRPE is working correctly 
+
+## Install from release 
+### download release versions (for release 1.2.1) 
+```bash
+[nagios@host ~]$ cd /home/nagios
+[nagios@host nagios]$ mkdir check_kubernetes
+[nagios@host nagios]$ cd check_kubernetes
+[nagios@host check_kubernetes]$ RELEASE_URL="https://github.com/T-Systems-MMS/check_kubernetes/releases/download/"
+[nagios@host check_kubernetes]$ VERSION="v1.2.1"
+[nagios@host check_kubernetes]$ wget ${RELEASE_URL}/${VERSION}/check_pods
+[nagios@host check_kubernetes]$ wget wget ${RELEASE_URL}/${VERSION}/check_nodes
+[nagios@host check_kubernetes]$ chmod 0750 check_pods check_nodes
+```
+
+## Install from Source 
+### Python environment
+The following steps have to be executed as Nagios/NRPE user (user who will run the checks).
+
+#### venv setup and clone
+```bash
+[nagios@host ~]$ cd /home/nagios
+[nagios@host nagios]$ python3 -m venv k8s_mon_venv
+[nagios@host nagios]$ source k8s_mon_venv/bin/activate
+[nagios@host nagios]$ git clone https://github.com/T-Systems-MMS/check_kubernetes.git
+[nagios@host nagios]$ cd check_kubernetes
+[nagios@host check_kubernetes]$ pip install -r requirements.txt 
+```
+
+## Kubernetes Service Account Setup 
+All files shown here can be found in folder k8s-sa-config. 
+
+### Service Account - 00_service_account.yaml
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: icinga-monitoring-sa
+```
+
+### ClusterRole - 01_clusterrole.yaml
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: icinga-monitoring
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+```
+
+### ClusterRoleBinding - 02_clusterrolebinding.yaml
+```yaml
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: icinga-monitor-pods
+subjects:
+- kind: ServiceAccount
+  name: icinga-monitoring-sa
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: icinga-monitoring
+  apiGroup: rbac.authorization.k8s.io
+```
+
+## Kubernetes - Get kube-config for service Account 
+### get_config.sh
+We assume here that the script is executed on a master node. If this is not the case you
+must change `API_SERVER` here. <br>
+If you've used another service account name also change `SERVICEACCOUNT_NAME` to reflect the change. 
+
+```bash
+#!/bin/bash
+
+API_SERVER="https://localhost:6443"
+SERVICEACCOUNT_NAME=$(kubectl get sa | grep icinga | awk '{ print $1 }')
+SECRET_NAME=$(kubectl get secrets | grep "${SERVICEACCOUNT_NAME}-token" | awk '{ print $1 }')
+
+if [[ ${SERVICEACCOUNT_NAME} == "" ]]; then
+    >&2 echo "Service account not found!"
+    exit 1
+else
+    >&2 echo "Found icinga Service Account: ${SECRET_NAME}"
+fi
+
+CA_CERT=$(kubectl get secret/"${SECRET_NAME}" -o jsonpath='{.data.ca\.crt}')
+SA_TOKEN=$(kubectl get secret/"${SECRET_NAME}" -o jsonpath='{.data.token}' | base64 --decode)
+NS=$(kubectl get secret/"${SECRET_NAME}" -o jsonpath='{.data.namespace}' | base64 --decode)
+
+echo "
+apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    certificate-authority-data: ${CA_CERT}
+    server: ${API_SERVER}
+contexts:
+- name: default-context
+  context:
+    cluster: default-cluster
+    namespace: ${NS}
+    user: default-user
+current-context: default-context
+users:
+- name: default-user
+  user:
+    token: ${SA_TOKEN}
+"
+```
+
+To generate the kube-config for the service account just call it and redirect the output to a location that is 
+accessible for nagios/nrpe.
+The user running the script must have the kubernetes connection and privileges to run kubectl commands 
+on cluster level ex. root   
+
+```bash
+chmod u+x get_config.sh
+./get_config.sh > /home/nagios/kube-config  
+```
+

--- a/k8s-sa-config/00_service_account.yaml
+++ b/k8s-sa-config/00_service_account.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: icinga-monitoring-sa

--- a/k8s-sa-config/01_clusterrole.yaml
+++ b/k8s-sa-config/01_clusterrole.yaml
@@ -5,5 +5,5 @@ metadata:
   name: icinga-monitoring
 rules:
 - apiGroups: [""]
-  resources: ["pods"]
+  resources: ["pods", "nodes"]
   verbs: ["get", "watch", "list"]

--- a/k8s-sa-config/01_clusterrole.yaml
+++ b/k8s-sa-config/01_clusterrole.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: icinga-monitoring
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]

--- a/k8s-sa-config/02_clusterrolebinding.yaml
+++ b/k8s-sa-config/02_clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: icinga-monitor-pods
+subjects:
+- kind: ServiceAccount
+  name: icinga-monitoring-sa
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: icinga-monitoring
+  apiGroup: rbac.authorization.k8s.io

--- a/k8s-sa-config/get_config.sh
+++ b/k8s-sa-config/get_config.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+API_SERVER="https://localhost:6443"
+SERVICEACCOUNT_NAME=$(kubectl get sa | grep icinga | awk '{ print $1 }')
+SECRET_NAME=$(kubectl get secrets | grep "${SERVICEACCOUNT_NAME}-token" | awk '{ print $1 }')
+
+if [[ ${SERVICEACCOUNT_NAME} == "" ]]; then
+    >&2 echo "Service account not found!"
+    exit 1
+else
+    >&2 echo "Found icinga Service Account: ${SECRET_NAME}"
+fi
+
+CA_CERT=$(kubectl get secret/"${SECRET_NAME}" -o jsonpath='{.data.ca\.crt}')
+SA_TOKEN=$(kubectl get secret/"${SECRET_NAME}" -o jsonpath='{.data.token}' | base64 --decode)
+NS=$(kubectl get secret/"${SECRET_NAME}" -o jsonpath='{.data.namespace}' | base64 --decode)
+
+echo "
+apiVersion: v1
+kind: Config
+clusters:
+- name: default-cluster
+  cluster:
+    certificate-authority-data: ${CA_CERT}
+    server: ${API_SERVER}
+contexts:
+- name: default-context
+  context:
+    cluster: default-cluster
+    namespace: ${NS}
+    user: default-user
+current-context: default-context
+users:
+- name: default-user
+  user:
+    token: ${SA_TOKEN}
+"


### PR DESCRIPTION
The pull requests includes the definitions for service account, clusterrole, clusterrolebinding and a bash script to generate a valid kube-config for check_kubernetes.  
The clustercole only contains "get", "watch" and "list" verbs for "pods" and "nodes" in all namespaces. 

Also added INSTALL.md which describes the way how the plugin can be installed with the given sa, cr and crb.